### PR TITLE
Better error management

### DIFF
--- a/code/src/bin/main_hbee.rs
+++ b/code/src/bin/main_hbee.rs
@@ -15,28 +15,23 @@ async fn exec(mut req: Request<Body>) -> Result<Response<Body>, DynError> {
         body.extend_from_slice(&chunk?);
     }
     let hbee_event: HBeeEvent = serde_json::from_slice(&body)?;
-    let hbee_service = HBeeService::new().await;
-    hbee_service
-        .execute_query(
-            hbee_event.query_id,
-            hbee_event.plan.parse()?,
-            hbee_event.hcomb_address,
-        )
-        .await?;
+    let parsed_plan = hbee_event.plan.parse()?;
+    tokio::spawn(async {
+        let hbee_service = HBeeService::new().await;
+        let res = hbee_service
+            .execute_query(hbee_event.query_id, parsed_plan, hbee_event.hcomb_address)
+            .await;
+        match res {
+            Ok(_) => println!("[hbee] success"),
+            Err(e) => println!("[hbee] exec error: {}", e),
+        };
+    });
     Ok(Response::new(Body::from("Ok!")))
-}
-
-async fn serve(req: Request<Body>) -> Result<Response<Body>, DynError> {
-    exec(req).await.map_err(|e| {
-        println!("[hbee] error: {}", e);
-        e
-    })
 }
 
 // this endpoint helps simulating lambda locally
 pub async fn start_hbee_server() -> Result<(), DynError> {
-    let make_svc =
-        make_service_fn(|_conn| async { Ok::<_, DynError>(service_fn(serve)) });
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, DynError>(service_fn(exec)) });
     let addr = ([0, 0, 0, 0], 3000).into();
     let server = Server::bind(&addr).serve(make_svc);
     println!("[hbee] Listening on http://{}", addr);

--- a/code/src/bin/main_integ.rs
+++ b/code/src/bin/main_integ.rs
@@ -6,13 +6,13 @@ mod main_hcomb;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::select! {
         res = main_fuse::start_fuse("localhost", "localhost") => {
-            println!("fuse result: {:?}", res);
+            println!("[integ] fuse result: {:?}", res);
         }
         res = main_hbee::start_hbee_server() => {
-            println!("hbee server failed: {:?}", res);
+            println!("[integ] hbee server failed: {:?}", res);
         }
         res = main_hcomb::start_hcomb_server() => {
-            println!("hcomb server failed: {:?}", res);
+            println!("[integ] hcomb server failed: {:?}", res);
         }
     }
     Ok(())

--- a/code/src/clients/flight_client.rs
+++ b/code/src/clients/flight_client.rs
@@ -5,11 +5,11 @@ use std::pin::Pin;
 use crate::flight_utils;
 use crate::models::HCombAddress;
 use crate::protobuf::LogicalPlanNode;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::Ticket;
 use datafusion::logical_plan::LogicalPlan;
-use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::Stream;
 use futures::StreamExt;
 use prost::Message;
@@ -18,7 +18,7 @@ use prost::Message;
 pub async fn call_do_get(
     address: &HCombAddress,
     plan: LogicalPlan,
-) -> Result<Pin<Box<dyn Stream<Item = RecordBatch>>>, Box<dyn Error>> {
+) -> Result<Pin<Box<dyn Stream<Item = ArrowResult<RecordBatch>>>>, Box<dyn Error>> {
     // Create Flight client
     let mut client = FlightServiceClient::connect(address.clone()).await?;
 
@@ -37,12 +37,12 @@ pub async fn call_do_get(
 pub async fn call_do_put(
     query_id: String,
     address: &HCombAddress,
-    results: SendableRecordBatchStream,
+    results: Vec<RecordBatch>,
 ) -> Result<(), Box<dyn Error>> {
     // Create Flight client after delay, to leave time for the server to boot
     tokio::time::delay_for(std::time::Duration::new(1, 0)).await;
 
-    let input = flight_utils::batches_to_flight(&query_id, results).await?;
+    let input = flight_utils::batch_vec_to_flight(&query_id, results).await?;
 
     let request = tonic::Request::new(input);
 
@@ -50,6 +50,29 @@ pub async fn call_do_put(
     // wait for the response to be complete but don't do anything with it
     client
         .do_put(request)
+        .await?
+        .into_inner()
+        .collect::<Vec<_>>()
+        .await;
+
+    Ok(())
+}
+
+pub async fn call_do_action(
+    query_id: String,
+    address: &HCombAddress,
+    action_type: String,
+) -> Result<(), Box<dyn Error>> {
+    let action = arrow_flight::Action {
+        body: query_id.as_bytes().to_owned(),
+        r#type: action_type,
+    };
+    let request = tonic::Request::new(action);
+
+    let mut client = FlightServiceClient::connect(address.clone()).await?;
+    // wait for the response to be complete but don't do anything with it
+    client
+        .do_action(request)
         .await?
         .into_inner()
         .collect::<Vec<_>>()

--- a/code/src/clients/range_cache.rs
+++ b/code/src/clients/range_cache.rs
@@ -123,9 +123,7 @@ impl RangeCache {
                             );
                         }
                         Err(err) => {
-                            // TODO Avoid casting err to string (needed to make it cloneable)
-                            file_map
-                                .insert(message.2, Download::Error(format!("{}", err)));
+                            file_map.insert(message.2, Download::Error(err.reason()));
                         }
                     }
                     cv_ref.notify_all();

--- a/code/src/clients/s3.rs
+++ b/code/src/clients/s3.rs
@@ -121,7 +121,10 @@ impl ChunkReader for S3FileAsync {
     self
       .cache
       .get(self.dler_id.clone(), self.file_id.clone(), start, length)
-      .map_err(|e| ParquetError::General(format!("{}", e)))
+      .map_err(|e| match e {
+        BuzzError::ParquetError(err) => err,
+        err => ParquetError::General(format!("{}", err)),
+      })
   }
 }
 

--- a/code/src/datasource/hcomb.rs
+++ b/code/src/datasource/hcomb.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::execution_plan::StreamExec;
 use arrow::datatypes::*;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use datafusion::datasource::datasource::Statistics;
 use datafusion::datasource::TableProvider;
@@ -12,7 +13,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use futures::Stream;
 
 pub struct HCombTable {
-    stream: Mutex<Option<Pin<Box<dyn Stream<Item = RecordBatch> + Send>>>>,
+    stream: Mutex<Option<Pin<Box<dyn Stream<Item = ArrowResult<RecordBatch>> + Send>>>>,
     query_id: String,
     nb_hbee: usize,
     schema: SchemaRef,
@@ -36,7 +37,10 @@ impl HCombTable {
         self.nb_hbee
     }
 
-    pub fn set(&self, stream: Pin<Box<dyn Stream<Item = RecordBatch> + Send>>) {
+    pub fn set(
+        &self,
+        stream: Pin<Box<dyn Stream<Item = ArrowResult<RecordBatch>> + Send>>,
+    ) {
         self.stream.lock().unwrap().replace(stream);
     }
 }

--- a/code/src/error.rs
+++ b/code/src/error.rs
@@ -80,6 +80,21 @@ impl BuzzError {
     pub fn internal(reason: &'static str) -> Self {
         return Self::Internal(reason.to_owned());
     }
+
+    pub fn reason(&self) -> String {
+        match *self {
+            BuzzError::ArrowError(ref desc) => format!("{}", desc),
+            BuzzError::ParquetError(ref desc) => format!("{}", desc),
+            BuzzError::DataFusionError(ref desc) => format!("{}", desc),
+            BuzzError::IoError(ref desc) => format!("{}", desc),
+            BuzzError::NotImplemented(ref desc) => format!("{}", desc),
+            BuzzError::Internal(ref desc) => format!("{}", desc),
+            BuzzError::Plan(ref desc) => format!("{}", desc),
+            BuzzError::Execution(ref desc) => format!("{}", desc),
+            BuzzError::HBee(ref desc) => format!("{}", desc),
+            BuzzError::Download(ref desc) => format!("{}", desc),
+        }
+    }
 }
 
 impl From<io::Error> for BuzzError {

--- a/code/src/error.rs
+++ b/code/src/error.rs
@@ -12,7 +12,6 @@ pub type Result<T> = result::Result<T, BuzzError>;
 
 /// Buzz error
 #[derive(Debug)]
-#[allow(missing_docs)]
 pub enum BuzzError {
     /// Error returned by arrow.
     ArrowError(ArrowError),
@@ -37,6 +36,10 @@ pub enum BuzzError {
     /// Error returned during execution of the query.
     /// Examples include files not found, errors in parsing certain types.
     Execution(String),
+    /// Error returned when hbee failed
+    HBee(String),
+    /// Error when downloading data from an external source
+    Download(String),
 }
 
 /// Creates an Internal error from a formatted string
@@ -126,6 +129,14 @@ impl Display for BuzzError {
             }
             BuzzError::Execution(ref desc) => {
                 write!(f, "Execution error: {}", desc)
+            }
+            BuzzError::HBee(ref desc) => {
+                // TODO the actual error from the bee should be transfered instead
+                // e.g the Download error
+                write!(f, "HBee error: {}", desc)
+            }
+            BuzzError::Download(ref desc) => {
+                write!(f, "Download error: {}", desc)
             }
         }
     }

--- a/code/src/execution_plan/s3_parquet.rs
+++ b/code/src/execution_plan/s3_parquet.rs
@@ -70,7 +70,7 @@ impl ParquetExec {
         tokio::task::spawn_blocking(move || {
             let file_reader = Arc::new(
                 SerializedFileReader::new(file.clone())
-                    .expect("Failed to create serialized reader"),
+                    .map_err(|e| DataFusionError::ParquetError(e))?,
             );
             let mut arrow_reader = ParquetFileArrowReader::new(file_reader.clone());
 
@@ -186,7 +186,7 @@ fn read_file(
     // TODO avoid footing being parsed twice here
     let file_reader = Arc::new(
         SerializedFileReader::new(file.clone())
-            .expect("Failed to create serialized reader"),
+            .map_err(|e| DataFusionError::ParquetError(e))?,
     );
     let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
     let mut batch_reader =

--- a/code/src/flight_utils.rs
+++ b/code/src/flight_utils.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::internal_err;
 use arrow::datatypes::Schema;
+use arrow::error::{ArrowError, Result as ArrowResult};
 use arrow::ipc::writer::IpcWriteOptions;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::utils::{
@@ -15,54 +16,97 @@ use arrow_flight::utils::{
 use arrow_flight::{flight_descriptor, FlightData, FlightDescriptor};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{Stream, StreamExt};
+use tonic::Status;
 
 /// Convert a flight stream to a tuple with the cmd in the first flight and a stream of RecordBatch
 pub async fn flight_to_batches(
     flights: tonic::Streaming<FlightData>,
-) -> Result<(String, impl Stream<Item = RecordBatch>), Box<dyn Error>> {
+) -> Result<(String, impl Stream<Item = ArrowResult<RecordBatch>>), Box<dyn Error>> {
     let mut flights = Box::pin(flights);
     let flight_data = flights.next().await.unwrap()?;
     let schema = Arc::new(Schema::try_from(&flight_data)?);
     let cmd = descriptor_to_cmd(flight_data.flight_descriptor)?;
 
     // all the remaining stream messages should be dictionary and record batches
-    let record_batch_stream = flights.map(move |flight_data| {
-        flight_data_to_arrow_batch(&flight_data.unwrap(), schema.clone())
-            .unwrap()
-            .unwrap()
+    let record_batch_stream = flights.map(move |flight_data_res| match flight_data_res {
+        Ok(flight_data) => {
+            flight_data_to_arrow_batch(&flight_data, Arc::clone(&schema)).unwrap()
+        }
+        Err(e) => Err(ArrowError::ExternalError(Box::new(e))),
     });
     Ok((cmd, record_batch_stream))
 }
 
-/// Convert RecordBatches and a cmd to a stream of flights
-pub async fn batches_to_flight(
+/// Convert a stream of RecordBatches and a cmd to a stream of flights
+pub async fn batch_stream_to_flight(
     cmd: &str,
     batches: SendableRecordBatchStream,
-) -> Result<impl Stream<Item = FlightData> + Send + Sync, Box<dyn Error>> {
+) -> Result<impl Stream<Item = Result<FlightData, Status>> + Send + Sync, Box<dyn Error>>
+{
     // TODO are all this IpcWriteOptions creations a problem?
-    let (sender, result) = tokio::sync::mpsc::unbounded_channel::<FlightData>();
+    let (sender, result) =
+        tokio::sync::mpsc::unbounded_channel::<Result<FlightData, Status>>();
 
     // create an initial FlightData message that sends schema
     let options = IpcWriteOptions::default();
     let mut flight_schema = flight_data_from_arrow_schema(&batches.schema(), &options);
     flight_schema.flight_descriptor = cmd_to_descriptor(&cmd);
-    sender.send(flight_schema)?;
+    sender.send(Ok(flight_schema))?;
 
     // use channels to make stream sync (required by tonic)
     // TODO what happens with errors (currently all unwrapped in spawned task)
     tokio::spawn(async move {
         // then stream the rest
         batches
-            .for_each(|batch| async {
+            .for_each(|batch_res| async {
                 let options = IpcWriteOptions::default();
-                flight_data_from_arrow_batch(&batch.unwrap(), &options)
-                    .into_iter()
-                    .for_each(|flight| (&sender).send(flight).unwrap());
+                match batch_res {
+                    Ok(batch) => {
+                        flight_data_from_arrow_batch(&batch, &options)
+                            .into_iter()
+                            .for_each(|flight| (&sender).send(Ok(flight)).unwrap());
+                    }
+                    Err(err) => {
+                        (&sender)
+                            .send(Err(Status::aborted(format!("{}", err))))
+                            .unwrap();
+                    }
+                };
             })
             .await;
     });
 
     Ok(result)
+}
+
+/// Convert a vector of RecordBatches and a cmd to a stream of flights
+/// If there are no batches (empty vec), a flight with an empty schema is sent
+pub async fn batch_vec_to_flight(
+    cmd: &str,
+    batches: Vec<RecordBatch>,
+) -> Result<impl Stream<Item = FlightData>, Box<dyn Error>> {
+    let schema;
+    if batches.len() == 0 {
+        schema = Arc::new(Schema::empty());
+    } else {
+        schema = batches[0].schema();
+    }
+    // create an initial FlightData message that sends schema
+    let options = IpcWriteOptions::default();
+    let mut flight_schema = flight_data_from_arrow_schema(&schema, &options);
+    flight_schema.flight_descriptor = cmd_to_descriptor(&cmd);
+
+    let mut flight_vec = vec![flight_schema];
+
+    let mut batches: Vec<FlightData> = batches
+        .iter()
+        .flat_map(|batch| flight_data_from_arrow_batch(batch, &options))
+        .collect();
+
+    // append batch vector to schema vector, so that the first message sent is the schema
+    flight_vec.append(&mut batches);
+
+    Ok(futures::stream::iter(flight_vec))
 }
 
 fn cmd_to_descriptor(cmd: &str) -> Option<FlightDescriptor> {

--- a/code/src/models/actions.rs
+++ b/code/src/models/actions.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+pub enum ActionType {
+    Fail,
+    Unknown,
+}
+
+impl ActionType {
+    pub fn from_string(serialized: String) -> Self {
+        match serialized.as_str() {
+            "FAIL" => ActionType::Fail,
+            _ => ActionType::Unknown,
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        match self {
+            ActionType::Fail => "FAIL".to_owned(),
+            ActionType::Unknown => "UNKNOWN".to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Fail {
+    #[serde(rename = "qid")]
+    pub query_id: String,
+    #[serde(rename = "r")]
+    pub reason: String,
+}

--- a/code/src/models/mod.rs
+++ b/code/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! Models are entities that are common to services
 
+pub mod actions;
 mod hbee_event;
 pub mod query;
 

--- a/code/src/services/fuse/fuse_service.rs
+++ b/code/src/services/fuse/fuse_service.rs
@@ -93,7 +93,7 @@ impl FuseService {
         // wait for hcombs to collect all the results and desplay them comb by comb
         println!("[fuse] collect hcombs");
         for hcomb_stream in hcomb_streams {
-            let result: Vec<RecordBatch> = hcomb_stream.collect::<Vec<_>>().await;
+            let result: Vec<RecordBatch> = hcomb_stream.try_collect::<Vec<_>>().await?;
             pretty::print_batches(&result).unwrap();
         }
 

--- a/code/src/services/fuse/hcomb_scheduler.rs
+++ b/code/src/services/fuse/hcomb_scheduler.rs
@@ -4,6 +4,7 @@ use crate::clients::flight_client;
 use crate::error::Result;
 use crate::internal_err;
 use crate::models::HCombAddress;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::logical_plan::LogicalPlan;
@@ -16,7 +17,7 @@ pub trait HCombScheduler {
         &self,
         address: &HCombAddress,
         plan: LogicalPlan,
-    ) -> Result<Pin<Box<dyn Stream<Item = RecordBatch>>>>;
+    ) -> Result<Pin<Box<dyn Stream<Item = ArrowResult<RecordBatch>>>>>;
 }
 
 pub struct HttpHCombScheduler;
@@ -27,7 +28,7 @@ impl HCombScheduler for HttpHCombScheduler {
         &self,
         address: &HCombAddress,
         plan: LogicalPlan,
-    ) -> Result<Pin<Box<dyn Stream<Item = RecordBatch>>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = ArrowResult<RecordBatch>>>>> {
         flight_client::call_do_get(address, plan)
             .await
             .map_err(|e| internal_err!("Could not get result from HComb: {}", e))

--- a/code/src/services/hbee/hbee_service.rs
+++ b/code/src/services/hbee/hbee_service.rs
@@ -6,7 +6,7 @@ use crate::clients::RangeCache;
 use crate::datasource::HBeeTable;
 use crate::error::Result;
 use crate::internal_err;
-use crate::models::HCombAddress;
+use crate::models::{actions::ActionType, HCombAddress};
 use crate::services::utils;
 use arrow::record_batch::RecordBatch;
 use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
@@ -45,11 +45,14 @@ impl HBeeService {
                 .await
                 .map_err(|e| internal_err!("Could not do_put hbee result: {}", e)),
             Err(query_err) => {
-                flight_client::call_do_action(query_id, &address, "FAIL".to_owned())
-                    .await
-                    .map_err(|e| {
-                        internal_err!("Could not do_action(FAIL) hbee: {}", e)
-                    })?;
+                flight_client::call_do_action(
+                    query_id,
+                    &address,
+                    ActionType::Fail,
+                    format!("{}", query_err),
+                )
+                .await
+                .map_err(|e| internal_err!("Could not do_action(FAIL) hbee: {}", e))?;
                 Err(query_err)
             }
         };

--- a/code/src/services/hbee/hbee_service.rs
+++ b/code/src/services/hbee/hbee_service.rs
@@ -8,6 +8,7 @@ use crate::error::Result;
 use crate::internal_err;
 use crate::models::HCombAddress;
 use crate::services::utils;
+use arrow::record_batch::RecordBatch;
 use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
 use datafusion::logical_plan::LogicalPlan;
 use datafusion::physical_plan::{merge::MergeExec, ExecutionPlan};
@@ -38,6 +39,29 @@ impl HBeeService {
     ) -> Result<()> {
         println!("[hbee] execute query");
         let start = Instant::now();
+
+        let exec_res = match self.query(plan).await {
+            Ok(query_res) => flight_client::call_do_put(query_id, &address, query_res)
+                .await
+                .map_err(|e| internal_err!("Could not do_put hbee result: {}", e)),
+            Err(query_err) => {
+                flight_client::call_do_action(query_id, &address, "FAIL".to_owned())
+                    .await
+                    .map_err(|e| {
+                        internal_err!("Could not do_action(FAIL) hbee: {}", e)
+                    })?;
+                Err(query_err)
+            }
+        };
+        println!("[hbee] run duration: {}", start.elapsed().as_millis());
+        exec_res
+    }
+
+    /// Execute the logical plan and collect the results
+    /// Collecting the results might increase latency and mem consumption but:
+    /// - reduces connection duration from hbee to hcomb, thus decreasing load on hcomb
+    /// - allows to collect exec errors at once, effectively choosing between do_put and FAIL action
+    async fn query(&self, plan: LogicalPlan) -> Result<Vec<RecordBatch>> {
         let plan = self.execution_context.optimize(&plan)?;
         let hbee_table = utils::find_table::<HBeeTable>(&plan)?;
         hbee_table.set_cache(Arc::clone(&self.range_cache));
@@ -47,20 +71,18 @@ impl HBeeService {
             "[hbee] partitions: {}",
             physical_plan.output_partitioning().partition_count()
         );
-        let res_stream = match physical_plan.output_partitioning().partition_count() {
-            0 => Err(internal_err!("Should have at least one partition")),
-            1 => physical_plan.execute(0).await.map_err(|e| e.into()),
+        let merged_plan = match physical_plan.output_partitioning().partition_count() {
+            0 => Err(internal_err!("Should have at least one partition"))?,
+            1 => physical_plan,
             _ => {
                 // merge into a single partition
                 let physical_plan = MergeExec::new(physical_plan.clone());
                 assert_eq!(1, physical_plan.output_partitioning().partition_count());
-                physical_plan.execute(0).await.map_err(|e| e.into())
+                Arc::new(physical_plan)
             }
-        }?;
-        flight_client::call_do_put(query_id, &address, res_stream)
+        };
+        datafusion::physical_plan::collect(merged_plan)
             .await
-            .map_err(|e| internal_err!("Could not do_put hbee result: {}", e))?;
-        println!("[hbee] run duration: {}", start.elapsed().as_millis());
-        Ok(())
+            .map_err(|e| e.into())
     }
 }


### PR DESCRIPTION
hbee errors are now propagated but:
- error wrappings are weird (example: `fuse result: Err(ArrowError(ExternalError(Status { code: Aborted, message: "External error: HBee error: FAIL action called: DataFusion error: Parquet error: Parquet error: Download error: Couldn\'t find AWS credentials in environment, credentials file, or IAM role." })))`)